### PR TITLE
feat: add opt-in response caching with configurable TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,11 @@ client := rocketflag.NewClient(WithAPIURL("https://api.example.com"))
 ### Caching responses
 
 To avoid hitting the API on every check, you can enable an in-memory cache by
-providing a default TTL via either `WithCacheSeconds` or `WithCacheMinutes`
-(not both — combining them returns an error from the next `GetFlag` call).
-Cached entries are keyed by flag ID **and** `UserContext`, so different
-cohorts/users still resolve independently.
+providing a default TTL via `WithCache`. Cached entries are keyed by flag ID
+**and** `UserContext`, so different cohorts/users still resolve independently.
 
 ```go
-client := rocketflag.NewClient(rocketflag.WithCacheMinutes(5))
+client := rocketflag.NewClient(rocketflag.WithCache(5 * time.Minute))
 
 // First call hits the API; subsequent calls within 5 minutes are served from cache.
 flag, err := client.GetFlag("flag-id", rocketflag.UserContext{"cohort": "beta"})
@@ -95,14 +93,17 @@ passing `0`:
 
 ```go
 // Force a fresh fetch, bypassing the cache.
-flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallSeconds(0))
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(0))
 
 // Use a shorter TTL just for this call.
-flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallSeconds(10))
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(10*time.Second))
 ```
 
-Caching is opt-in — without `WithCacheSeconds`/`WithCacheMinutes` or a per-call
-override, every call goes to the API.
+Caching is opt-in — without `WithCache` or a per-call override, every call
+goes to the API. The cache has no size cap and entries are only evicted when
+their key is re-requested after expiry; if you call with high-cardinality
+`UserContext` values (e.g. per-user IDs), construct a new client periodically
+to release memory.
 
 ### Chaining custom client options
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ client := rocketflag.NewClient(WithAPIURL("https://api.example.com"))
 
 ### Caching responses
 
-To avoid hitting the API on every check, you can enable an in-memory cache with
-a TTL that suits your application. Cached entries are keyed by flag ID **and**
-`UserContext`, so different cohorts/users still resolve independently.
+To avoid hitting the API on every check, you can enable an in-memory cache by
+providing a default TTL via either `WithCacheSeconds` or `WithCacheMinutes`
+(not both — combining them returns an error from the next `GetFlag` call).
+Cached entries are keyed by flag ID **and** `UserContext`, so different
+cohorts/users still resolve independently.
 
 ```go
-import "time"
-
-client := rocketflag.NewClient(rocketflag.WithCache(5 * time.Minute))
+client := rocketflag.NewClient(rocketflag.WithCacheMinutes(5))
 
 // First call hits the API; subsequent calls within 5 minutes are served from cache.
 flag, err := client.GetFlag("flag-id", rocketflag.UserContext{"cohort": "beta"})
@@ -95,13 +95,14 @@ passing `0`:
 
 ```go
 // Force a fresh fetch, bypassing the cache.
-flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(0))
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallSeconds(0))
 
 // Use a shorter TTL just for this call.
-flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(10 * time.Second))
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallSeconds(10))
 ```
 
-Caching is opt-in — without `WithCache`, every call goes to the API.
+Caching is opt-in — without `WithCacheSeconds`/`WithCacheMinutes` or a per-call
+override, every call goes to the API.
 
 ### Chaining custom client options
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,34 @@ By default, RocketFlag will use the RocketFlag API. This is https://api.rocketfl
 client := rocketflag.NewClient(WithAPIURL("https://api.example.com"))
 ```
 
+### Caching responses
+
+To avoid hitting the API on every check, you can enable an in-memory cache with
+a TTL that suits your application. Cached entries are keyed by flag ID **and**
+`UserContext`, so different cohorts/users still resolve independently.
+
+```go
+import "time"
+
+client := rocketflag.NewClient(rocketflag.WithCache(5 * time.Minute))
+
+// First call hits the API; subsequent calls within 5 minutes are served from cache.
+flag, err := client.GetFlag("flag-id", rocketflag.UserContext{"cohort": "beta"})
+```
+
+You can override the TTL for a single call, or disable caching for that call by
+passing `0`:
+
+```go
+// Force a fresh fetch, bypassing the cache.
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(0))
+
+// Use a shorter TTL just for this call.
+flag, err := client.GetFlag("flag-id", nil, rocketflag.WithCallTTL(10 * time.Second))
+```
+
+Caching is opt-in — without `WithCache`, every call goes to the API.
+
 ### Chaining custom client options
 
 ```go

--- a/rocketflag.go
+++ b/rocketflag.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 )
 
 // FlagStatus represents the status of a feature flag.
@@ -19,9 +21,11 @@ type UserContext map[string]interface{}
 
 // Client is a RocketFlag API client.
 type Client struct {
-	version string
-	apiUrl  string
-	client  *http.Client
+	version    string
+	apiUrl     string
+	client     *http.Client
+	cache      *cache
+	defaultTTL time.Duration
 }
 
 // ClientOption defines a function type that modifies the Client.
@@ -48,16 +52,43 @@ func WithHTTPClient(client *http.Client) ClientOption {
 	}
 }
 
+// WithCache enables in-memory response caching with the given default TTL.
+// A non-positive ttl leaves caching disabled.
+func WithCache(ttl time.Duration) ClientOption {
+	return func(c *Client) {
+		if ttl <= 0 {
+			return
+		}
+		c.defaultTTL = ttl
+		c.cache = newCache()
+	}
+}
+
+// CallOption modifies behaviour of a single GetFlag call.
+type CallOption func(*callOptions)
+
+type callOptions struct {
+	ttl    time.Duration
+	ttlSet bool
+}
+
+// WithCallTTL overrides the cache TTL for a single GetFlag call. A ttl of 0
+// disables caching for that call even if a default is configured.
+func WithCallTTL(ttl time.Duration) CallOption {
+	return func(o *callOptions) {
+		o.ttl = ttl
+		o.ttlSet = true
+	}
+}
+
 // NewClient creates a new Client with optional configurations.
 func NewClient(opts ...ClientOption) *Client {
-	// Default values
 	client := &Client{
 		version: "v1",
 		apiUrl:  "https://api.rocketflag.app",
 		client:  http.DefaultClient,
 	}
 
-	// Apply functional options
 	for _, opt := range opts {
 		opt(client)
 	}
@@ -66,7 +97,11 @@ func NewClient(opts ...ClientOption) *Client {
 }
 
 // GetFlag retrieves a feature flag from the RocketFlag API.
-func (c *Client) GetFlag(flagID string, userContext UserContext) (*FlagStatus, error) {
+func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOption) (*FlagStatus, error) {
+	co := callOptions{ttl: c.defaultTTL}
+	for _, opt := range opts {
+		opt(&co)
+	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/flags/%s", c.apiUrl, c.version, flagID))
 	if err != nil {
@@ -77,7 +112,17 @@ func (c *Client) GetFlag(flagID string, userContext UserContext) (*FlagStatus, e
 	for k, v := range userContext {
 		q.Set(k, fmt.Sprintf("%v", v))
 	}
-	u.RawQuery = q.Encode()
+	encoded := q.Encode()
+	u.RawQuery = encoded
+
+	cacheActive := c.cache != nil && co.ttl > 0
+	var key string
+	if cacheActive {
+		key = flagID + "?" + encoded
+		if cached, ok := c.cache.get(key); ok {
+			return cached, nil
+		}
+	}
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -99,5 +144,43 @@ func (c *Client) GetFlag(flagID string, userContext UserContext) (*FlagStatus, e
 		return nil, fmt.Errorf("error decoding response: %w", err)
 	}
 
+	if cacheActive {
+		c.cache.set(key, &flag, co.ttl)
+	}
+
 	return &flag, nil
+}
+
+type cacheEntry struct {
+	flag      *FlagStatus
+	expiresAt time.Time
+}
+
+type cache struct {
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+func newCache() *cache {
+	return &cache{entries: make(map[string]cacheEntry)}
+}
+
+func (c *cache) get(key string) (*FlagStatus, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return entry.flag, true
+}
+
+func (c *cache) set(key string, flag *FlagStatus, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = cacheEntry{flag: flag, expiresAt: time.Now().Add(ttl)}
 }

--- a/rocketflag.go
+++ b/rocketflag.go
@@ -21,14 +21,11 @@ type UserContext map[string]interface{}
 
 // Client is a RocketFlag API client.
 type Client struct {
-	version      string
-	apiUrl       string
-	client       *http.Client
-	cache        *cache
-	defaultTTL   time.Duration
-	cacheSeconds *int
-	cacheMinutes *int
-	configErr    error
+	version    string
+	apiUrl     string
+	client     *http.Client
+	cache      *cache
+	defaultTTL time.Duration
 }
 
 // ClientOption defines a function type that modifies the Client.
@@ -55,19 +52,11 @@ func WithHTTPClient(client *http.Client) ClientOption {
 	}
 }
 
-// WithCacheSeconds enables in-memory response caching with the given default
-// TTL in seconds. Cannot be combined with WithCacheMinutes.
-func WithCacheSeconds(seconds int) ClientOption {
+// WithCache enables in-memory response caching with the given default TTL.
+// A non-positive duration leaves caching disabled.
+func WithCache(ttl time.Duration) ClientOption {
 	return func(c *Client) {
-		c.cacheSeconds = &seconds
-	}
-}
-
-// WithCacheMinutes enables in-memory response caching with the given default
-// TTL in minutes. Cannot be combined with WithCacheSeconds.
-func WithCacheMinutes(minutes int) ClientOption {
-	return func(c *Client) {
-		c.cacheMinutes = &minutes
+		c.defaultTTL = ttl
 	}
 }
 
@@ -75,31 +64,21 @@ func WithCacheMinutes(minutes int) ClientOption {
 type CallOption func(*callOptions)
 
 type callOptions struct {
-	seconds *int
-	minutes *int
+	ttl    time.Duration
+	ttlSet bool
 }
 
-// WithCallSeconds overrides the cache TTL for a single GetFlag call in
-// seconds. A value of 0 disables caching for that call even if a default is
-// configured. Cannot be combined with WithCallMinutes.
-func WithCallSeconds(seconds int) CallOption {
+// WithCallTTL overrides the cache TTL for a single GetFlag call. A zero or
+// negative duration disables caching for that call even if a client default
+// is configured.
+func WithCallTTL(ttl time.Duration) CallOption {
 	return func(o *callOptions) {
-		o.seconds = &seconds
+		o.ttl = ttl
+		o.ttlSet = true
 	}
 }
 
-// WithCallMinutes overrides the cache TTL for a single GetFlag call in
-// minutes. A value of 0 disables caching for that call. Cannot be combined
-// with WithCallSeconds.
-func WithCallMinutes(minutes int) CallOption {
-	return func(o *callOptions) {
-		o.minutes = &minutes
-	}
-}
-
-// NewClient creates a new Client with optional configurations. Configuration
-// errors (such as conflicting cache options) are deferred and surfaced from
-// GetFlag.
+// NewClient creates a new Client with optional configurations.
 func NewClient(opts ...ClientOption) *Client {
 	client := &Client{
 		version: "v1",
@@ -111,15 +90,6 @@ func NewClient(opts ...ClientOption) *Client {
 		opt(client)
 	}
 
-	if client.cacheSeconds != nil && client.cacheMinutes != nil {
-		client.configErr = fmt.Errorf("client cache options cannot specify both WithCacheSeconds and WithCacheMinutes")
-		return client
-	}
-	if client.cacheSeconds != nil {
-		client.defaultTTL = time.Duration(*client.cacheSeconds) * time.Second
-	} else if client.cacheMinutes != nil {
-		client.defaultTTL = time.Duration(*client.cacheMinutes) * time.Minute
-	}
 	client.cache = newCache()
 
 	return client
@@ -127,23 +97,14 @@ func NewClient(opts ...ClientOption) *Client {
 
 // GetFlag retrieves a feature flag from the RocketFlag API.
 func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOption) (*FlagStatus, error) {
-	if c.configErr != nil {
-		return nil, c.configErr
-	}
-
 	co := callOptions{}
 	for _, opt := range opts {
 		opt(&co)
 	}
-	if co.seconds != nil && co.minutes != nil {
-		return nil, fmt.Errorf("call cache options cannot specify both WithCallSeconds and WithCallMinutes")
-	}
 
 	ttl := c.defaultTTL
-	if co.seconds != nil {
-		ttl = time.Duration(*co.seconds) * time.Second
-	} else if co.minutes != nil {
-		ttl = time.Duration(*co.minutes) * time.Minute
+	if co.ttlSet {
+		ttl = co.ttl
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/flags/%s", c.apiUrl, c.version, flagID))
@@ -155,13 +116,12 @@ func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOpt
 	for k, v := range userContext {
 		q.Set(k, fmt.Sprintf("%v", v))
 	}
-	encoded := q.Encode()
-	u.RawQuery = encoded
+	u.RawQuery = q.Encode()
 
-	cacheActive := c.cache != nil && ttl > 0
+	cacheActive := ttl > 0
 	var key string
 	if cacheActive {
-		key = flagID + "?" + encoded
+		key = u.String()
 		if cached, ok := c.cache.get(key); ok {
 			return cached, nil
 		}
@@ -188,14 +148,14 @@ func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOpt
 	}
 
 	if cacheActive {
-		c.cache.set(key, &flag, ttl)
+		c.cache.set(key, flag, ttl)
 	}
 
 	return &flag, nil
 }
 
 type cacheEntry struct {
-	flag      *FlagStatus
+	flag      FlagStatus
 	expiresAt time.Time
 }
 
@@ -219,10 +179,11 @@ func (c *cache) get(key string) (*FlagStatus, bool) {
 		delete(c.entries, key)
 		return nil, false
 	}
-	return entry.flag, true
+	flag := entry.flag
+	return &flag, true
 }
 
-func (c *cache) set(key string, flag *FlagStatus, ttl time.Duration) {
+func (c *cache) set(key string, flag FlagStatus, ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[key] = cacheEntry{flag: flag, expiresAt: time.Now().Add(ttl)}

--- a/rocketflag.go
+++ b/rocketflag.go
@@ -21,11 +21,14 @@ type UserContext map[string]interface{}
 
 // Client is a RocketFlag API client.
 type Client struct {
-	version    string
-	apiUrl     string
-	client     *http.Client
-	cache      *cache
-	defaultTTL time.Duration
+	version      string
+	apiUrl       string
+	client       *http.Client
+	cache        *cache
+	defaultTTL   time.Duration
+	cacheSeconds *int
+	cacheMinutes *int
+	configErr    error
 }
 
 // ClientOption defines a function type that modifies the Client.
@@ -52,15 +55,19 @@ func WithHTTPClient(client *http.Client) ClientOption {
 	}
 }
 
-// WithCache enables in-memory response caching with the given default TTL.
-// A non-positive ttl leaves caching disabled.
-func WithCache(ttl time.Duration) ClientOption {
+// WithCacheSeconds enables in-memory response caching with the given default
+// TTL in seconds. Cannot be combined with WithCacheMinutes.
+func WithCacheSeconds(seconds int) ClientOption {
 	return func(c *Client) {
-		if ttl <= 0 {
-			return
-		}
-		c.defaultTTL = ttl
-		c.cache = newCache()
+		c.cacheSeconds = &seconds
+	}
+}
+
+// WithCacheMinutes enables in-memory response caching with the given default
+// TTL in minutes. Cannot be combined with WithCacheSeconds.
+func WithCacheMinutes(minutes int) ClientOption {
+	return func(c *Client) {
+		c.cacheMinutes = &minutes
 	}
 }
 
@@ -68,20 +75,31 @@ func WithCache(ttl time.Duration) ClientOption {
 type CallOption func(*callOptions)
 
 type callOptions struct {
-	ttl    time.Duration
-	ttlSet bool
+	seconds *int
+	minutes *int
 }
 
-// WithCallTTL overrides the cache TTL for a single GetFlag call. A ttl of 0
-// disables caching for that call even if a default is configured.
-func WithCallTTL(ttl time.Duration) CallOption {
+// WithCallSeconds overrides the cache TTL for a single GetFlag call in
+// seconds. A value of 0 disables caching for that call even if a default is
+// configured. Cannot be combined with WithCallMinutes.
+func WithCallSeconds(seconds int) CallOption {
 	return func(o *callOptions) {
-		o.ttl = ttl
-		o.ttlSet = true
+		o.seconds = &seconds
 	}
 }
 
-// NewClient creates a new Client with optional configurations.
+// WithCallMinutes overrides the cache TTL for a single GetFlag call in
+// minutes. A value of 0 disables caching for that call. Cannot be combined
+// with WithCallSeconds.
+func WithCallMinutes(minutes int) CallOption {
+	return func(o *callOptions) {
+		o.minutes = &minutes
+	}
+}
+
+// NewClient creates a new Client with optional configurations. Configuration
+// errors (such as conflicting cache options) are deferred and surfaced from
+// GetFlag.
 func NewClient(opts ...ClientOption) *Client {
 	client := &Client{
 		version: "v1",
@@ -93,14 +111,39 @@ func NewClient(opts ...ClientOption) *Client {
 		opt(client)
 	}
 
+	if client.cacheSeconds != nil && client.cacheMinutes != nil {
+		client.configErr = fmt.Errorf("client cache options cannot specify both WithCacheSeconds and WithCacheMinutes")
+		return client
+	}
+	if client.cacheSeconds != nil {
+		client.defaultTTL = time.Duration(*client.cacheSeconds) * time.Second
+	} else if client.cacheMinutes != nil {
+		client.defaultTTL = time.Duration(*client.cacheMinutes) * time.Minute
+	}
+	client.cache = newCache()
+
 	return client
 }
 
 // GetFlag retrieves a feature flag from the RocketFlag API.
 func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOption) (*FlagStatus, error) {
-	co := callOptions{ttl: c.defaultTTL}
+	if c.configErr != nil {
+		return nil, c.configErr
+	}
+
+	co := callOptions{}
 	for _, opt := range opts {
 		opt(&co)
+	}
+	if co.seconds != nil && co.minutes != nil {
+		return nil, fmt.Errorf("call cache options cannot specify both WithCallSeconds and WithCallMinutes")
+	}
+
+	ttl := c.defaultTTL
+	if co.seconds != nil {
+		ttl = time.Duration(*co.seconds) * time.Second
+	} else if co.minutes != nil {
+		ttl = time.Duration(*co.minutes) * time.Minute
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/flags/%s", c.apiUrl, c.version, flagID))
@@ -115,7 +158,7 @@ func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOpt
 	encoded := q.Encode()
 	u.RawQuery = encoded
 
-	cacheActive := c.cache != nil && co.ttl > 0
+	cacheActive := c.cache != nil && ttl > 0
 	var key string
 	if cacheActive {
 		key = flagID + "?" + encoded
@@ -145,7 +188,7 @@ func (c *Client) GetFlag(flagID string, userContext UserContext, opts ...CallOpt
 	}
 
 	if cacheActive {
-		c.cache.set(key, &flag, co.ttl)
+		c.cache.set(key, &flag, ttl)
 	}
 
 	return &flag, nil

--- a/rocketflag_test.go
+++ b/rocketflag_test.go
@@ -239,7 +239,7 @@ func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}, nil
 }
 
-func newCountingClient(t *testing.T, flag *FlagStatus) (*Client, *countingTransport) {
+func newCountingClient(t *testing.T, flag *FlagStatus, opts ...ClientOption) (*Client, *countingTransport) {
 	t.Helper()
 	body, err := json.Marshal(flag)
 	if err != nil {
@@ -247,14 +247,13 @@ func newCountingClient(t *testing.T, flag *FlagStatus) (*Client, *countingTransp
 	}
 	transport := &countingTransport{body: body}
 	httpClient := &http.Client{Transport: transport}
-	return NewClient(WithHTTPClient(httpClient)), transport
+	allOpts := append([]ClientOption{WithHTTPClient(httpClient)}, opts...)
+	return NewClient(allOpts...), transport
 }
 
 func TestGetFlag_CacheHit(t *testing.T) {
 	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
-	client, transport := newCountingClient(t, flag)
-	client.cache = newCache()
-	client.defaultTTL = time.Minute
+	client, transport := newCountingClient(t, flag, WithCache(time.Minute))
 
 	for i := 0; i < 3; i++ {
 		got, err := client.GetFlag("123", UserContext{"cohort": "beta"})
@@ -273,9 +272,7 @@ func TestGetFlag_CacheHit(t *testing.T) {
 
 func TestGetFlag_CacheExpiry(t *testing.T) {
 	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
-	client, transport := newCountingClient(t, flag)
-	client.cache = newCache()
-	client.defaultTTL = 10 * time.Millisecond
+	client, transport := newCountingClient(t, flag, WithCache(10*time.Millisecond))
 
 	if _, err := client.GetFlag("123", nil); err != nil {
 		t.Fatal(err)
@@ -292,9 +289,7 @@ func TestGetFlag_CacheExpiry(t *testing.T) {
 
 func TestGetFlag_CacheKeyIncludesUserContext(t *testing.T) {
 	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
-	client, transport := newCountingClient(t, flag)
-	client.cache = newCache()
-	client.defaultTTL = time.Minute
+	client, transport := newCountingClient(t, flag, WithCache(time.Minute))
 
 	if _, err := client.GetFlag("123", UserContext{"cohort": "alpha"}); err != nil {
 		t.Fatal(err)
@@ -308,16 +303,14 @@ func TestGetFlag_CacheKeyIncludesUserContext(t *testing.T) {
 	}
 }
 
-func TestGetFlag_PerCallTTLOverride(t *testing.T) {
+func TestGetFlag_PerCallTTLDisables(t *testing.T) {
 	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
-	client, transport := newCountingClient(t, flag)
-	client.cache = newCache()
-	client.defaultTTL = time.Minute
+	client, transport := newCountingClient(t, flag, WithCache(time.Minute))
 
-	if _, err := client.GetFlag("123", nil, WithCallSeconds(0)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.GetFlag("123", nil, WithCallSeconds(0)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -330,28 +323,15 @@ func TestGetFlag_PerCallTTLEnables(t *testing.T) {
 	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
 	client, transport := newCountingClient(t, flag)
 
-	if _, err := client.GetFlag("123", nil, WithCallMinutes(1)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallTTL(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.GetFlag("123", nil, WithCallMinutes(1)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallTTL(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 
 	if n := atomic.LoadInt32(&transport.count); n != 1 {
 		t.Errorf("expected 1 HTTP request when per-call TTL enables cache, got %d", n)
-	}
-}
-
-func TestGetFlag_PerCallConflictReturnsError(t *testing.T) {
-	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
-	client, _ := newCountingClient(t, flag)
-
-	_, err := client.GetFlag("123", nil, WithCallSeconds(30), WithCallMinutes(1))
-	if err == nil {
-		t.Fatal("expected error when both WithCallSeconds and WithCallMinutes are set")
-	}
-	if !strings.Contains(err.Error(), "both WithCallSeconds and WithCallMinutes") {
-		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -370,34 +350,25 @@ func TestGetFlag_NoCacheByDefault(t *testing.T) {
 	}
 }
 
-func TestWithCacheMinutes_EnablesCaching(t *testing.T) {
-	client := NewClient(WithCacheMinutes(1))
-	if client.cache == nil {
-		t.Fatal("expected cache to be initialised")
-	}
-	if client.defaultTTL != time.Minute {
-		t.Errorf("expected defaultTTL=1m, got %v", client.defaultTTL)
-	}
-}
+func TestGetFlag_CachedResultIsolatedFromCallerMutation(t *testing.T) {
+	flag := &FlagStatus{Name: "original", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag, WithCache(time.Minute))
 
-func TestWithCacheSeconds_EnablesCaching(t *testing.T) {
-	client := NewClient(WithCacheSeconds(30))
-	if client.cache == nil {
-		t.Fatal("expected cache to be initialised")
+	first, err := client.GetFlag("123", nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if client.defaultTTL != 30*time.Second {
-		t.Errorf("expected defaultTTL=30s, got %v", client.defaultTTL)
-	}
-}
+	first.Name = "mutated"
 
-func TestClientCacheConflictReturnsError(t *testing.T) {
-	client := NewClient(WithCacheSeconds(30), WithCacheMinutes(1))
-	_, err := client.GetFlag("123", nil)
-	if err == nil {
-		t.Fatal("expected error from GetFlag when both cache options are set")
+	second, err := client.GetFlag("123", nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "both WithCacheSeconds and WithCacheMinutes") {
-		t.Errorf("unexpected error: %v", err)
+	if second.Name != "original" {
+		t.Errorf("cached value was mutated by caller: got %q, want %q", second.Name, "original")
+	}
+	if n := atomic.LoadInt32(&transport.count); n != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", n)
 	}
 }
 

--- a/rocketflag_test.go
+++ b/rocketflag_test.go
@@ -10,7 +10,9 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // Mocking the http.RoundTripper interface to control HTTP responses
@@ -218,6 +220,134 @@ func TestGetFlag_UserContext(t *testing.T) {
 
 	if !reflect.DeepEqual(actualQuery, expectedQuery) {
 		t.Errorf("Expected query: %+v, got: %+v", expectedQuery, actualQuery)
+	}
+}
+
+// countingTransport tracks how many requests pass through it and returns the
+// supplied response (fresh body each time so multiple reads work).
+type countingTransport struct {
+	count int32
+	body  []byte
+}
+
+func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&t.count, 1)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(t.body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func newCountingClient(t *testing.T, flag *FlagStatus) (*Client, *countingTransport) {
+	t.Helper()
+	body, err := json.Marshal(flag)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	transport := &countingTransport{body: body}
+	httpClient := &http.Client{Transport: transport}
+	return NewClient(WithHTTPClient(httpClient)), transport
+}
+
+func TestGetFlag_CacheHit(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+	client.cache = newCache()
+	client.defaultTTL = time.Minute
+
+	for i := 0; i < 3; i++ {
+		got, err := client.GetFlag("123", UserContext{"cohort": "beta"})
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(got, flag) {
+			t.Fatalf("call %d: got %+v, want %+v", i, got, flag)
+		}
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", n)
+	}
+}
+
+func TestGetFlag_CacheExpiry(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+	client.cache = newCache()
+	client.defaultTTL = 10 * time.Millisecond
+
+	if _, err := client.GetFlag("123", nil); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(25 * time.Millisecond)
+	if _, err := client.GetFlag("123", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 2 {
+		t.Errorf("expected 2 HTTP requests after expiry, got %d", n)
+	}
+}
+
+func TestGetFlag_CacheKeyIncludesUserContext(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+	client.cache = newCache()
+	client.defaultTTL = time.Minute
+
+	if _, err := client.GetFlag("123", UserContext{"cohort": "alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetFlag("123", UserContext{"cohort": "beta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 2 {
+		t.Errorf("expected 2 HTTP requests for differing contexts, got %d", n)
+	}
+}
+
+func TestGetFlag_PerCallTTLOverride(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+	client.cache = newCache()
+	client.defaultTTL = time.Minute
+
+	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 2 {
+		t.Errorf("expected 2 HTTP requests when per-call TTL disables cache, got %d", n)
+	}
+}
+
+func TestGetFlag_NoCacheByDefault(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+
+	for i := 0; i < 3; i++ {
+		if _, err := client.GetFlag("123", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 3 {
+		t.Errorf("expected 3 HTTP requests without caching, got %d", n)
+	}
+}
+
+func TestWithCache_EnablesCaching(t *testing.T) {
+	client := NewClient(WithCache(time.Minute))
+	if client.cache == nil {
+		t.Fatal("expected cache to be initialised")
+	}
+	if client.defaultTTL != time.Minute {
+		t.Errorf("expected defaultTTL=1m, got %v", client.defaultTTL)
 	}
 }
 

--- a/rocketflag_test.go
+++ b/rocketflag_test.go
@@ -314,15 +314,44 @@ func TestGetFlag_PerCallTTLOverride(t *testing.T) {
 	client.cache = newCache()
 	client.defaultTTL = time.Minute
 
-	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallSeconds(0)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.GetFlag("123", nil, WithCallTTL(0)); err != nil {
+	if _, err := client.GetFlag("123", nil, WithCallSeconds(0)); err != nil {
 		t.Fatal(err)
 	}
 
 	if n := atomic.LoadInt32(&transport.count); n != 2 {
 		t.Errorf("expected 2 HTTP requests when per-call TTL disables cache, got %d", n)
+	}
+}
+
+func TestGetFlag_PerCallTTLEnables(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, transport := newCountingClient(t, flag)
+
+	if _, err := client.GetFlag("123", nil, WithCallMinutes(1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetFlag("123", nil, WithCallMinutes(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := atomic.LoadInt32(&transport.count); n != 1 {
+		t.Errorf("expected 1 HTTP request when per-call TTL enables cache, got %d", n)
+	}
+}
+
+func TestGetFlag_PerCallConflictReturnsError(t *testing.T) {
+	flag := &FlagStatus{Name: "f", Enabled: true, ID: "123"}
+	client, _ := newCountingClient(t, flag)
+
+	_, err := client.GetFlag("123", nil, WithCallSeconds(30), WithCallMinutes(1))
+	if err == nil {
+		t.Fatal("expected error when both WithCallSeconds and WithCallMinutes are set")
+	}
+	if !strings.Contains(err.Error(), "both WithCallSeconds and WithCallMinutes") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -341,13 +370,34 @@ func TestGetFlag_NoCacheByDefault(t *testing.T) {
 	}
 }
 
-func TestWithCache_EnablesCaching(t *testing.T) {
-	client := NewClient(WithCache(time.Minute))
+func TestWithCacheMinutes_EnablesCaching(t *testing.T) {
+	client := NewClient(WithCacheMinutes(1))
 	if client.cache == nil {
 		t.Fatal("expected cache to be initialised")
 	}
 	if client.defaultTTL != time.Minute {
 		t.Errorf("expected defaultTTL=1m, got %v", client.defaultTTL)
+	}
+}
+
+func TestWithCacheSeconds_EnablesCaching(t *testing.T) {
+	client := NewClient(WithCacheSeconds(30))
+	if client.cache == nil {
+		t.Fatal("expected cache to be initialised")
+	}
+	if client.defaultTTL != 30*time.Second {
+		t.Errorf("expected defaultTTL=30s, got %v", client.defaultTTL)
+	}
+}
+
+func TestClientCacheConflictReturnsError(t *testing.T) {
+	client := NewClient(WithCacheSeconds(30), WithCacheMinutes(1))
+	_, err := client.GetFlag("123", nil)
+	if err == nil {
+		t.Fatal("expected error from GetFlag when both cache options are set")
+	}
+	if !strings.Contains(err.Error(), "both WithCacheSeconds and WithCacheMinutes") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds WithCache(ttl) client option and WithCallTTL(ttl) per-call override so callers can avoid hitting the API on every flag check. Cache keys include the UserContext so different cohorts resolve independently. Caching is opt-in and backwards-compatible.