### PR TITLE
Revert module path to lowercase github.com/rocketflag/go-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This SDK provides a convenient way to interact with the RocketFlag API from your
 ## Installation
 
 ```bash
-go get github.com/RocketFlag/go-sdk
+go get github.com/rocketflag/go-sdk
 ```
 
 ## Basic Usage
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log"
 
-	rocketflag "github.com/RocketFlag/go-sdk"
+	rocketflag "github.com/rocketflag/go-sdk"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/RocketFlag/go-sdk
+module github.com/rocketflag/go-sdk
 
 go 1.22.3


### PR DESCRIPTION
v1.1.2 silently changed the module path `rocketflag` → `RocketFlag`. Go module paths are case-sensitive, so this is a **breaking change** with no major-version bump — it breaks every consumer pinned to v1.1.0 (which declared the lowercase path) and anyone following the published docs.

Reverts `go.mod` + README back to the lowercase path that v1.1.0 and earlier shipped. **Cut `v1.2.0` from this** as a clean release that supersedes the broken `v1.1.2` tag.

Note: the caching feature (`WithCache`/`WithCallTTL`) already shipped in v1.1.0, so v1.2.0 adds no new code beyond restoring the correct module path — the minor bump just gives a clean, well-labelled current release.