### PR TITLE
Bump deprecated actions off Node 20

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -18,7 +18,7 @@ jobs:
       # Mint a short-lived token for the docs repo so we can dispatch to it.
       - name: Mint docs App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
       - name: Install dependencies
         run: go mod tidy


### PR DESCRIPTION
Bumps `actions/checkout@v4 → @v7` and `actions/create-github-app-token@v1 → @v3` across workflows to clear the Node 20 deprecation warnings (both latest majors run on Node 24). Version-pin changes only.